### PR TITLE
Use ArrayBuffers instead of Node Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here are some non-exhaustive examples:
 ```typescript
 import { Decoder } from "binary-util"
 
-const data = Buffer.from([
+const data = new Uint8Array([
   0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
 ])
 const decoder = new Decoder(data)

--- a/src/decoder.test.ts
+++ b/src/decoder.test.ts
@@ -1,11 +1,9 @@
-import { Buffer } from "node:buffer"
-
 import { Decoder } from "binary-util"
 import { describe, expect, it } from "vitest"
 
 describe(".currentOffset", () => {
   it("example works as described", () => {
-    const buffer = Buffer.from([0x01, 0x01, 0x00, 0x00])
+    const buffer = new Uint8Array([0x01, 0x01, 0x00, 0x00])
     const decoder = new Decoder(buffer)
     expect(decoder.readUint32()).toBe(257)
     expect(decoder.currentOffset).toBe(4)
@@ -14,7 +12,7 @@ describe(".currentOffset", () => {
 
 describe(".endianness", () => {
   it("example works as described", () => {
-    const buffer = Buffer.from([0x00, 0x00, 0x01, 0x01])
+    const buffer = new Uint8Array([0x00, 0x00, 0x01, 0x01])
     const decoder = new Decoder(buffer)
     decoder.endianness("big")
     expect(decoder.readUint32()).toBe(257)
@@ -23,7 +21,7 @@ describe(".endianness", () => {
 
 describe(".seek", () => {
   it("example works as described", () => {
-    const buffer = Buffer.from([0xff, 0xff, 0x01, 0x00])
+    const buffer = new Uint8Array([0xff, 0xff, 0x01, 0x00])
     const decoder = new Decoder(buffer)
     expect(decoder.seek(2)).toBe(0)
     expect(decoder.readUint16()).toBe(1)
@@ -32,7 +30,7 @@ describe(".seek", () => {
 
 describe(".goto", () => {
   it("example works as described", () => {
-    const buffer = Buffer.from([0xff, 0xff, 0x01, 0x00])
+    const buffer = new Uint8Array([0xff, 0xff, 0x01, 0x00])
     const decoder = new Decoder(buffer)
     expect(decoder.readUint16()).toBe(65535)
     expect(decoder.goto(0)).toBe(2)
@@ -43,21 +41,21 @@ describe(".goto", () => {
 
 describe(".alignTo", () => {
   it("skips forwards correctly if diff if positive", () => {
-    const decoder = new Decoder(Buffer.alloc(16))
+    const decoder = new Decoder(new Uint8Array(16))
     decoder.seek(12)
     decoder.alignTo(16)
     expect(decoder.currentOffset).toBe(16)
   })
 
   it("skips forwards correctly if diff if negative", () => {
-    const decoder = new Decoder(Buffer.alloc(16))
+    const decoder = new Decoder(new Uint8Array(16))
     decoder.seek(4)
     decoder.alignTo(16)
     expect(decoder.currentOffset).toBe(16)
   })
 
   it("does nothing if already aligned", () => {
-    const decoder = new Decoder(Buffer.alloc(16))
+    const decoder = new Decoder(new Uint8Array(16))
     decoder.seek(8)
     decoder.alignTo(4)
     expect(decoder.currentOffset).toBe(8)
@@ -66,7 +64,7 @@ describe(".alignTo", () => {
   it("example works as described", () => {
     // prettier-ignore
     // Assume we have a header 5 bytes long, then 3 bytes of padding up to 8 bytes in, then more data
-    const buffer = Buffer.from([
+    const buffer = new Uint8Array([
       0x74, 0xee, 0xb2, 0x36, 0x0c, 0x00, 0x00, 0x00,
       0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ])
@@ -83,13 +81,13 @@ describe(".alignTo", () => {
 describe("integers", () => {
   describe(".readInt8", () => {
     it("example works as described", () => {
-      const decoder = new Decoder(Buffer.from([0xff]))
+      const decoder = new Decoder(new Uint8Array([0xff]))
       expect(decoder.readInt8()).toBe(-1)
     })
 
     it("pointer example works as described", () => {
-      //                                      (3   + 0)  | pad | -1
-      const decoder = new Decoder(Buffer.from([0x03, 0x00, 0x00, 0xff]))
+      //                                             (3   + 0)  | pad | -1
+      const decoder = new Decoder(new Uint8Array([0x03, 0x00, 0x00, 0xff]))
       const pointer = decoder.readUint16()
       expect(pointer).toBe(3)
       expect(decoder.readInt8({ pointer })).toBe(-1)
@@ -98,13 +96,13 @@ describe("integers", () => {
 
   describe(".readUint8", () => {
     it("example works as described", () => {
-      const decoder = new Decoder(Buffer.from([0xff]))
+      const decoder = new Decoder(new Uint8Array([0xff]))
       expect(decoder.readUint8()).toBe(255)
     })
 
     it("pointer example works as described", () => {
-      //                                      (3   + 0)  | pad | -1
-      const decoder = new Decoder(Buffer.from([0x03, 0x00, 0x00, 0xff]))
+      //                                             (3   + 0)  | pad | -1
+      const decoder = new Decoder(new Uint8Array([0x03, 0x00, 0x00, 0xff]))
       const pointer = decoder.readUint16()
       expect(pointer).toBe(3)
       expect(decoder.readUint8({ pointer })).toBe(255)
@@ -113,12 +111,12 @@ describe("integers", () => {
 
   describe(".readInt16", () => {
     it("example works as described", () => {
-      const decoder = new Decoder(Buffer.from([0xff, 0xff]))
+      const decoder = new Decoder(new Uint8Array([0xff, 0xff]))
       expect(decoder.readInt16()).toBe(-1)
     })
 
     it("pointer example works as described", () => {
-      const decoder = new Decoder(Buffer.from([0x03, 0x00, 0x00, 0xff, 0xff]))
+      const decoder = new Decoder(new Uint8Array([0x03, 0x00, 0x00, 0xff, 0xff]))
       const pointer = decoder.readUint16()
       expect(pointer).toBe(3)
       expect(decoder.readInt16({ pointer })).toBe(-1)
@@ -127,13 +125,13 @@ describe("integers", () => {
 
   describe(".readUint16", () => {
     it("decodes a value correctly", () => {
-      const decoder = new Decoder(Buffer.from([0xff, 0xff]))
+      const decoder = new Decoder(new Uint8Array([0xff, 0xff]))
       expect(decoder.readUint16()).toBe(65535)
     })
 
     it("decodes a value via a pointer correctly", () => {
-      //                                      (3   + 0)  | pad | -1
-      const decoder = new Decoder(Buffer.from([0x03, 0x00, 0x00, 0xff, 0xff]))
+      //                                             (3   + 0)  | pad | -1
+      const decoder = new Decoder(new Uint8Array([0x03, 0x00, 0x00, 0xff, 0xff]))
       const pointer = decoder.readUint16()
       expect(pointer).toBe(3)
       expect(decoder.readUint16({ pointer })).toBe(65535)
@@ -143,25 +141,31 @@ describe("integers", () => {
 
 describe(".readBuffer", () => {
   it("returns part of buffer", () => {
-    const decoder = new Decoder(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]))
-    expect(decoder.readBuffer({ length: 2 })).toEqual(Buffer.from([0x01, 0x02]))
+    const decoder = new Decoder(new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]))
+    expect(decoder.readBuffer({ length: 2 })).toEqual(new Uint8Array([0x01, 0x02]))
   })
 
   it("uses currentOffset", () => {
-    const decoder = new Decoder(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]))
+    const decoder = new Decoder(
+      new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
+    )
     decoder.seek(2)
-    expect(decoder.readBuffer({ length: 2 })).toEqual(Buffer.from([0x03, 0x04]))
+    expect(decoder.readBuffer({ length: 2 })).toEqual(new Uint8Array([0x03, 0x04]))
   })
 
   it("pointer option works", () => {
-    const decoder = new Decoder(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x09]))
-    expect(decoder.readBuffer({ pointer: 0x06, length: 2 })).toEqual(Buffer.from([0x08, 0x09]))
+    const decoder = new Decoder(
+      new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x09]),
+    )
+    expect(decoder.readBuffer({ pointer: 0x06, length: 2 })).toEqual(
+      new Uint8Array([0x08, 0x09]),
+    )
   })
 })
 
 describe(".readString", () => {
   it("should parse strings correctly", () => {
-    const data = Buffer.from("testhelloworld")
+    const data = new TextEncoder().encode("testhelloworld")
 
     const decoder = new Decoder(data)
     expect(decoder.readString({ length: 4 })).toBe("test")
@@ -170,7 +174,7 @@ describe(".readString", () => {
   })
 
   it("should parse zeroed strings correctly", () => {
-    const data = Buffer.from("test\x00hello\x00world\x00")
+    const data = new TextEncoder().encode("test\x00hello\x00world\x00")
 
     const decoder = new Decoder(data)
     expect(decoder.readString({ zeroed: true })).toBe("test")
@@ -180,7 +184,7 @@ describe(".readString", () => {
 })
 
 it("should parse the README example", () => {
-  const data = Buffer.from([
+  const data = new Uint8Array([
     0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
   ])
   const decoder = new Decoder(data)
@@ -190,7 +194,9 @@ it("should parse the README example", () => {
   expect(decoder.readString({ length: 7 })).toBe(", World")
 
   // Or you can use it more ergonomically when possible
-  const decoder2 = new Decoder(Buffer.alloc(2, 2))
+  const filledArray = new Uint8Array(2)
+  filledArray.fill(2)
+  const decoder2 = new Decoder(filledArray)
   const result = {
     a: decoder2.readUint8(),
     b: decoder2.readUint8(),
@@ -200,7 +206,7 @@ it("should parse the README example", () => {
 })
 
 it("should allow parsing simple data", () => {
-  const testBuffer = Buffer.alloc(17)
+  const testBuffer = new Uint8Array(17)
   const values = [3257, 3263, 6483, 9773]
   const view = new DataView(testBuffer.buffer)
   view.setInt8(0, 4)

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,11 +1,9 @@
-import { type Buffer } from "node:buffer"
-
 type BaseOptions = {
   pointer?: number
 }
 
 type BaseStringOptions = {
-  encoding?: BufferEncoding
+  encoding?: "utf8"
 }
 
 type BufferOptions = BaseOptions & { length: number }
@@ -13,7 +11,7 @@ type BufferOptions = BaseOptions & { length: number }
 type StringOptions = BaseStringOptions & ({ length: number } | { zeroed: boolean })
 
 export class Decoder {
-  #buffer: Buffer
+  #buffer: Uint8Array
   #currentOffset = 0
   #littleEndian = true
 
@@ -23,7 +21,7 @@ export class Decoder {
    *
    * Defaults to little endian.
    */
-  constructor(buffer: Buffer) {
+  constructor(buffer: Uint8Array) {
     this.#buffer = buffer
   }
 
@@ -32,8 +30,8 @@ export class Decoder {
    *
    * @example
    * ```ts
-   * //                          1   + 256 + 0   + 0
-   * const buffer = Buffer.from([0x01, 0x01, 0x00, 0x00])
+   * //                                     1   + 256 + 0   + 0
+   * const buffer = new Uint8Array([0x01, 0x01, 0x00, 0x00])
    * const decoder = new Decoder(buffer)
    * decoder.readUint32() // 257
    * decoder.currentOffset // 4
@@ -48,8 +46,8 @@ export class Decoder {
    * @param endianness - `big` or `little`
    * @example
    * ```ts
-   * //                          0   + 0   + 256 + 1
-   * const buffer = Buffer.from([0x00, 0x00, 0x01, 0x01])
+   * //                                     0   + 0   + 256 + 1
+   * const buffer = new Uint8Array([0x00, 0x00, 0x01, 0x01])
    * const decoder = new Decoder(buffer)
    * decoder.endianness("big")
    * decoder.readUint32() // 257
@@ -65,8 +63,8 @@ export class Decoder {
    * @returns The previous offset.
    * @example
    * ```ts
-   * //                         (max + max)|(1   + 0)
-   * const buffer = Buffer.from([0xFF, 0xFF, 0x01, 0x00])
+   * //                                    (max + max)|(1   + 0)
+   * const buffer = new Uint8Array([0xFF, 0xFF, 0x01, 0x00])
    * const decoder = new Decoder(buffer)
    * decoder.seek(2) // 0
    * decoder.readUint16() // 1
@@ -84,8 +82,8 @@ export class Decoder {
    * @returns The previous offset.
    * @example
    * ```ts
-   * //                         (max + max)|(1   + 0)
-   * const buffer = Buffer.from([0xff, 0xff, 0x01, 0x00])
+   * //                                    (max + max)|(1   + 0)
+   * const buffer = new Uint8Array([0xff, 0xff, 0x01, 0x00])
    * const decoder = new Decoder(buffer)
    * decoder.readUint16() // 65535
    * decoder.goto(0) // 2
@@ -109,7 +107,7 @@ export class Decoder {
    * @example
    * ```ts
    * // Assume we have a header 5 bytes long, then 3 bytes of padding up to 8 bytes in, then more data
-   * const buffer = Buffer.from([
+   * const buffer = new Uint8Array([
    *   0x74, 0xee, 0xb2, 0x36, 0x0c, 0x00, 0x00, 0x00,
    *   0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
    * ])
@@ -142,13 +140,13 @@ export class Decoder {
    * @returns Value between -128 and 127.
    * @example
    * ```ts
-   * const decoder = new Decoder(Buffer.from([0xff]))
+   * const decoder = new Decoder(new Uint8Array([0xff]))
    * expect(decoder.readInt8()).toBe(-1)
    * ```
    * @example Read via pointer offset
    * ```ts
-   * //                                      (3   + 0)  | pad | -1
-   * const decoder = new Decoder(Buffer.from([0x03, 0x00, 0x00, 0xff]))
+   * //                                               (3   + 0)  | pad | -1
+   * const decoder = new Decoder(new Uint8Array([0x03, 0x00, 0x00, 0xff]))
    * const pointer = decoder.readUint16() // 3
    * decoder.readInt8({ pointer }) // -1
    * ```
@@ -174,13 +172,13 @@ export class Decoder {
    * @returns Value between 0 and 255.
    * @example
    * ```ts
-   * const decoder = new Decoder(Buffer.from([0xff]))
+   * const decoder = new Decoder(new Uint8Array([0xff]))
    * expect(decoder.readInt8()).toBe(255)
    * ```
    * @example Read via pointer offset
    * ```ts
-   * //                                      (3   + 0)  | pad | -1
-   * const decoder = new Decoder(Buffer.from([0x03, 0x00, 0x00, 0xff]))
+   * //                                               (3   + 0)  | pad | -1
+   * const decoder = new Decoder(new Uint8Array([0x03, 0x00, 0x00, 0xff]))
    * const pointer = decoder.readUint16() // 3
    * decoder.readInt8({ pointer }) // 255
    * ```
@@ -377,7 +375,7 @@ export class Decoder {
    * @param opts.length {number} - Length of slice (not inclusive).
    * @param opts.pointer {number} - See {@link Decoder#readUint8}.
    */
-  readBuffer(opts: BufferOptions): Buffer {
+  readBuffer(opts: BufferOptions): Uint8Array {
     const offset = opts.pointer ?? this.#currentOffset
     const result = this.#buffer.subarray(offset, offset + opts.length)
 
@@ -396,17 +394,17 @@ export class Decoder {
    * @param opts.encoding - Defaults to `utf8`.
    * @example Zeroed
    * ```ts
-   * const decoder = new Decoder(Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00]))
+   * const decoder = new Decoder(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00]))
    * decoder.readString({ zeroed: true }) // "hello"
    * ```
    * @example Length
    * ```ts
-   * const decoder = new Decoder(Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f]))
+   * const decoder = new Decoder(new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]))
    * decoder.readString({ length: 5 }) // "hello"
    * ```
    */
   readString(opts: StringOptions): string {
-    let strBuffer: Buffer | null = null
+    let strBuffer: Uint8Array | null = null
 
     if ("length" in opts && opts.length != null) {
       strBuffer = this.readBuffer(opts)
@@ -428,6 +426,9 @@ export class Decoder {
       throw new Error("You need to specify either `zeroed` or `length`.")
     }
 
-    return strBuffer.toString(opts.encoding ?? "utf8")
+    this.#textDecoder ??= new TextDecoder(opts.encoding ?? "utf8")
+    return this.#textDecoder.decode(strBuffer)
   }
+
+  #textDecoder!: TextDecoder
 }

--- a/src/encoder.test.ts
+++ b/src/encoder.test.ts
@@ -212,14 +212,16 @@ describe(".setString", () => {
     const encoder = new Encoder(5)
     encoder.setString("test")
 
-    expect(encoder.buffer.toString()).toBe("test\x00")
+    const textDecoder = new TextDecoder()
+    expect(textDecoder.decode(encoder.buffer)).toBe("test\x00")
   })
 
   it("should write 2-byte characters correctly", () => {
     const encoder = new Encoder()
     encoder.setString("Ûbercharge")
 
-    expect(encoder.buffer.toString()).toBe("Ûbercharge\x00")
+    const textDecoder = new TextDecoder()
+    expect(textDecoder.decode(encoder.buffer)).toBe("Ûbercharge\x00")
   })
 
   it("should grow the buffer if needed", () => {
@@ -230,15 +232,7 @@ describe(".setString", () => {
     const buffer = encoder.buffer
     expect(buffer.length).toBe(7)
     expect(buffer[0]).toBe(1)
-    expect(buffer.subarray(2).toString("utf8")).toBe("test\x00")
-  })
-
-  it("uses the provided encoding", () => {
-    const encoder = new Encoder()
-    encoder.setString("TEST", { encoding: "utf-16le" })
-
-    const buffer = encoder.buffer
-    expect(buffer.toString("utf-16le")).toBe("TEST\x00")
-    expect(buffer.toString("utf8")).not.toBe("TEST\x00")
+    const textDecoder = new TextDecoder()
+    expect(textDecoder.decode(buffer.subarray(2))).toBe("test\x00")
   })
 })

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -1,3 +1,5 @@
+import { allocateUnsafe } from "@easrng.net/allocate"
+
 type BaseOptions = {
   into?: number
 }
@@ -16,10 +18,11 @@ export class Encoder {
   #view: DataView
   #currentOffset = 0
   #littleEndian = true
+  #textEncoder?: TextEncoder
 
   constructor(length: number = 0) {
-    this.#buffer = new Uint8Array(length)
-    this.#view = new DataView(this.#buffer.buffer)
+    this.#buffer = allocateUnsafe(length)
+    this.#view = new DataView(this.#buffer.buffer, this.#buffer.byteOffset, this.#buffer.byteLength)
   }
 
   get currentOffset(): number {
@@ -31,7 +34,7 @@ export class Encoder {
   }
 
   get buffer(): Uint8Array {
-    const newBuffer = new Uint8Array(this.#buffer.length)
+    const newBuffer = allocateUnsafe(this.#buffer.length)
     newBuffer.set(this.#buffer)
     return newBuffer
   }
@@ -40,12 +43,11 @@ export class Encoder {
     this.#littleEndian = endianness === "little"
   }
 
-  // TODO: use transfer or grow instead
   grow(size: number): void {
-    const newBuffer = new Uint8Array(this.#buffer.length + size)
+    const newBuffer = allocateUnsafe(this.#buffer.length + size)
     newBuffer.set(this.#buffer)
     this.#buffer = newBuffer
-    this.#view = new DataView(this.#buffer.buffer)
+    this.#view = new DataView(this.#buffer.buffer, this.#buffer.byteOffset, this.#buffer.byteLength)
   }
 
   growIfNeeded(incomingSize: number): void {
@@ -80,26 +82,6 @@ export class Encoder {
 
     this.#currentOffset += alignment - diff
   }
-
-  // #createSetMethod =
-  //   <Value extends number | bigint = number>(
-  //     size: number,
-  //     littleEndianFunction: BufferWriteFunction,
-  //     bigEndianFunction?: BufferWriteFunction,
-  //   ): WriteNumberFunction<Value> =>
-  //   (value, opts) => {
-  //     if (opts?.into == null || opts.into + size > this.#buffer.length) {
-  //       this.growIfNeeded(size)
-  //     }
-  //
-  //     this.#buffer[
-  //       !this.#littleEndian && bigEndianFunction != null ? bigEndianFunction : littleEndianFunction
-  //     ](value as never, opts?.into ?? this.#currentOffset, size)
-  //
-  //     if (opts?.into == null) {
-  //       this.#currentOffset += size
-  //     }
-  //   }
 
   setInt8: WriteNumberFunction<number> = (value, opts) => {
     if (opts?.into == null || opts.into + 1 > this.#buffer.length) {
@@ -221,6 +203,4 @@ export class Encoder {
       this.#currentOffset += value.length
     }
   }
-
-  #textEncoder!: TextEncoder
 }

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -1,15 +1,10 @@
-import { Buffer } from "node:buffer"
-
-type StartsWith<E extends keyof Buffer, P extends string> = E extends `${P}${string}` ? E : never
-
-type EndsWith<E extends keyof Buffer, P extends string> = E extends `${string}${P}` ? E : never
 
 type BaseOptions = {
   into?: number
 }
 
 type StringOptions = BaseOptions & {
-  encoding?: BufferEncoding
+  encoding?: "utf8"
 }
 
 type WriteNumberFunction<Value extends number | bigint = number | bigint> = (
@@ -17,15 +12,15 @@ type WriteNumberFunction<Value extends number | bigint = number | bigint> = (
   opts?: BaseOptions,
 ) => void
 
-type BufferWriteFunction = EndsWith<StartsWith<keyof Buffer, "write">, "BE" | "LE" | "8">
-
 export class Encoder {
-  #buffer: Buffer
+  #buffer: Uint8Array
+  #view: DataView
   #currentOffset = 0
   #littleEndian = true
 
   constructor(length: number = 0) {
-    this.#buffer = Buffer.alloc(length)
+    this.#buffer = new Uint8Array(length)
+    this.#view = new DataView(this.#buffer.buffer)
   }
 
   get currentOffset(): number {
@@ -36,9 +31,9 @@ export class Encoder {
     return this.#buffer.length
   }
 
-  get buffer(): Buffer {
-    const newBuffer = Buffer.alloc(this.#buffer.length)
-    this.#buffer.copy(newBuffer)
+  get buffer(): Uint8Array {
+    const newBuffer = new Uint8Array(this.#buffer.length)
+    newBuffer.set(this.#buffer)
     return newBuffer
   }
 
@@ -47,7 +42,10 @@ export class Encoder {
   }
 
   grow(size: number): void {
-    this.#buffer = Buffer.concat([this.#buffer, Buffer.alloc(size)])
+    const newBuffer = new Uint8Array(this.#buffer.length + size)
+    newBuffer.set(this.#buffer)
+    this.#buffer = newBuffer
+    this.#view = new DataView(this.#buffer.buffer)
   }
 
   growIfNeeded(incomingSize: number): void {
@@ -83,71 +81,146 @@ export class Encoder {
     this.#currentOffset += alignment - diff
   }
 
-  #createSetMethod =
-    <Value extends number | bigint = number>(
-      size: number,
-      littleEndianFunction: BufferWriteFunction,
-      bigEndianFunction?: BufferWriteFunction,
-    ): WriteNumberFunction<Value> =>
-    (value, opts) => {
-      if (opts?.into == null || opts.into + size > this.#buffer.length) {
-        this.growIfNeeded(size)
-      }
+  // #createSetMethod =
+  //   <Value extends number | bigint = number>(
+  //     size: number,
+  //     littleEndianFunction: BufferWriteFunction,
+  //     bigEndianFunction?: BufferWriteFunction,
+  //   ): WriteNumberFunction<Value> =>
+  //   (value, opts) => {
+  //     if (opts?.into == null || opts.into + size > this.#buffer.length) {
+  //       this.growIfNeeded(size)
+  //     }
+  //
+  //     this.#buffer[
+  //       !this.#littleEndian && bigEndianFunction != null ? bigEndianFunction : littleEndianFunction
+  //     ](value as never, opts?.into ?? this.#currentOffset, size)
+  //
+  //     if (opts?.into == null) {
+  //       this.#currentOffset += size
+  //     }
+  //   }
 
-      this.#buffer[
-        !this.#littleEndian && bigEndianFunction != null ? bigEndianFunction : littleEndianFunction
-      ](value as never, opts?.into ?? this.#currentOffset, size)
-
-      if (opts?.into == null) {
-        this.#currentOffset += size
-      }
+  setInt8: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 1 > this.#buffer.length) {
+      this.growIfNeeded(1)
     }
+    this.#view.setInt8(opts?.into ?? this.#currentOffset, value)
+    if (opts?.into == null) {
+      this.#currentOffset += 1
+    }
+  }
 
-  setInt8: WriteNumberFunction = this.#createSetMethod(1, "writeInt8")
+  setUint8: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 1 > this.#buffer.length) {
+      this.growIfNeeded(1)
+    }
+    this.#view.setUint8(opts?.into ?? this.#currentOffset, value)
+    if (opts?.into == null) {
+      this.#currentOffset += 1
+    }
+  }
 
-  setUint8: WriteNumberFunction = this.#createSetMethod(1, "writeUInt8")
+  setInt16: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 2 > this.#buffer.length) {
+      this.growIfNeeded(2)
+    }
+    this.#view.setInt16(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 2
+    }
+  }
 
-  setInt16: WriteNumberFunction = this.#createSetMethod(2, "writeInt16LE", "writeInt16BE")
+  setUint16: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 2 > this.#buffer.length) {
+      this.growIfNeeded(2)
+    }
+    this.#view.setUint16(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 2
+    }
+  }
 
-  setUint16: WriteNumberFunction = this.#createSetMethod(2, "writeUInt16LE", "writeUInt16BE")
+  setInt32: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 4 > this.#buffer.length) {
+      this.growIfNeeded(4)
+    }
+    this.#view.setInt32(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 4
+    }
+  }
 
-  setInt32: WriteNumberFunction = this.#createSetMethod(4, "writeInt32LE", "writeInt32BE")
+  setUint32: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 4 > this.#buffer.length) {
+      this.growIfNeeded(4)
+    }
+    this.#view.setUint32(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 4
+    }
+  }
 
-  setUint32: WriteNumberFunction = this.#createSetMethod(4, "writeUInt32LE", "writeUInt32BE")
+  setInt64: WriteNumberFunction<bigint> = (value, opts) => {
+    if (opts?.into == null || opts.into + 8 > this.#buffer.length) {
+      this.growIfNeeded(8)
+    }
+    this.#view.setBigInt64(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 8
+    }
+  }
 
-  setInt64: WriteNumberFunction<bigint> = this.#createSetMethod(
-    8,
-    "writeBigInt64LE",
-    "writeBigInt64BE",
-  )
+  setUint64: WriteNumberFunction<bigint> = (value, opts) => {
+    if (opts?.into == null || opts.into + 8 > this.#buffer.length) {
+      this.growIfNeeded(8)
+    }
+    this.#view.setBigUint64(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 8
+    }
+  }
 
-  setUint64: WriteNumberFunction<bigint> = this.#createSetMethod(
-    8,
-    "writeBigUInt64LE",
-    "writeBigUInt64BE",
-  )
+  setFloat: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 4 > this.#buffer.length) {
+      this.growIfNeeded(4)
+    }
+    this.#view.setFloat32(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 4
+    }
+  }
 
-  setFloat: WriteNumberFunction = this.#createSetMethod(4, "writeFloatLE", "writeFloatBE")
-
-  setDouble: WriteNumberFunction = this.#createSetMethod(8, "writeDoubleLE", "writeDoubleBE")
+  setDouble: WriteNumberFunction<number> = (value, opts) => {
+    if (opts?.into == null || opts.into + 8 > this.#buffer.length) {
+      this.growIfNeeded(8)
+    }
+    this.#view.setFloat64(opts?.into ?? this.#currentOffset, value, this.#littleEndian)
+    if (opts?.into == null) {
+      this.#currentOffset += 8
+    }
+  }
 
   setString(value: string, opts?: StringOptions): void {
-    const data = Buffer.from(`${value}\x00`, opts?.encoding ?? "utf8")
+    this.#textEncoder ??= new TextEncoder()
+    const data = this.#textEncoder.encode(`${value}\x00`)
 
     this.growIfNeeded(data.byteLength)
-    data.copy(this.#buffer, opts?.into ?? this.#currentOffset)
+    this.#buffer.set(data, opts?.into ?? this.#currentOffset)
 
     if (opts?.into == null) {
       this.#currentOffset += data.byteLength
     }
   }
 
-  setBuffer(value: Buffer, opts?: BaseOptions): void {
+  setBuffer(value: Uint8Array, opts?: BaseOptions): void {
     this.growIfNeeded(value.length)
 
-    value.copy(this.#buffer, opts?.into ?? this.#currentOffset)
+    this.#buffer.set(value, opts?.into ?? this.#currentOffset)
     if (opts?.into == null) {
       this.#currentOffset += value.length
     }
   }
+
+  #textEncoder!: TextEncoder
 }

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -1,4 +1,3 @@
-
 type BaseOptions = {
   into?: number
 }
@@ -41,6 +40,7 @@ export class Encoder {
     this.#littleEndian = endianness === "little"
   }
 
+  // TODO: use transfer or grow instead
   grow(size: number): void {
     const newBuffer = new Uint8Array(this.#buffer.length + size)
     newBuffer.set(this.#buffer)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "exactOptionalPropertyTypes": false,
 
     // Extra types
-    "types": ["node"]
+    "lib": ["dom", "es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
+    "types": []
   },
 
   "include": ["./**/*"],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 
   env: { TEST: false },
 
-  platform: "node",
+  platform: "neutral",
   format: "esm",
   dts: { oxc: true },
   fixedExtension: true,


### PR DESCRIPTION
this pr uses arraybuffers instead of node's buffers for the operations, allowing browser usage.

im not sure if this is a good idea, i want to at least benchmark both versions to make sure its not ungodly slower

having benchmarked, decoding using buffer is 1.7x faster than using arraybuffers. in browsers it would presumably still be slower with a polyfill